### PR TITLE
fix /gp URL handling in the Amazon module

### DIFF
--- a/modules/Amazon/Amazon.py
+++ b/modules/Amazon/Amazon.py
@@ -1,10 +1,10 @@
-
 import discord
 from discord.ext import commands
 import json
 import bot_utils
 import re
 from urllib.parse import urlparse
+from .amazon_url_utils import shorten_amazon_url
 
 
 class Amazon(commands.Cog):
@@ -32,10 +32,7 @@ class Amazon(commands.Cog):
         for s in urls:
             if ('amazon' in s) or ('amzn' in s):
                 try:
-                    if any([i in s for i in ['.co.uk', '.com', '.de']]):
-                        short_link = ('https://smile.' + re.search('ama*zo*n.*?\/', s)[0] + re.search('\/(dp|gp)\/', s)[0][1:] + re.search('\/[a-zA-Z0-9]{10}\/', s)[0][1:])
-                    else:
-                        short_link = ('https://www.' + re.search('ama*zo*n.*?\/', s)[0] + re.search('\/(dp|gp)\/', s)[0][1:] + re.search('\/[a-zA-Z0-9]{10}\/', s)[0][1:])
+                    short_link = shorten_amazon_url(s)
                     new_content = message.content.replace(s, short_link)
 
                     replace = True

--- a/modules/Amazon/amazon_url_utils.py
+++ b/modules/Amazon/amazon_url_utils.py
@@ -1,0 +1,9 @@
+import re
+
+
+def shorten_amazon_url(s):
+    if any([i in s for i in ['.co.uk', '.com', '.de']]):
+        short_link = ('https://smile.' + re.search('ama*zo*n.*?\/', s)[0] + re.search('\/(dp|gp/product)\/', s)[0][1:] + re.search('\/[a-zA-Z0-9]{10}\/?', s)[0][1:])
+    else:
+        short_link = ('https://www.' + re.search('ama*zo*n.*?\/', s)[0] + re.search('\/(dp|gp/product)\/', s)[0][1:] + re.search('\/[a-zA-Z0-9]{10}\/?', s)[0][1:])
+    return short_link

--- a/modules/Amazon/test_amazon_url_utils.py
+++ b/modules/Amazon/test_amazon_url_utils.py
@@ -1,0 +1,25 @@
+import unittest
+from amazon_url_utils import shorten_amazon_url
+
+
+class TestAmazonUrlUtils(unittest.TestCase):
+
+    def test_gp(self):
+        testCase = 'https://www.amazon.com/gp/product/B08CGGRZ3M/ref=ppx_yo_dt_b_asin_title_o01_s00?ie=UTF8&psc=1'
+        self.assertEqual(shorten_amazon_url(testCase), 'https://smile.amazon.com/gp/product/B08CGGRZ3M/')
+
+    def test_dp(self):
+        testCase = 'https://www.amazon.com/dp/B08CGGRZ3M/'
+        self.assertEqual(shorten_amazon_url(testCase), 'https://smile.amazon.com/dp/B08CGGRZ3M/')
+
+    def test_dp_product(self):
+        # these links don't occur naturally in the wild
+        testCase = 'https://www.amazon.com/dp/product/B08CGGRZ3M/1'
+        self.assertEqual(shorten_amazon_url(testCase), 'https://smile.amazon.com/dp/B08CGGRZ3M/')
+
+    def test_smile_unsupported(self):
+        testCase = 'https://www.amazon.ca/dp/product/B08CGGRZ3M/1'
+        self.assertEqual(shorten_amazon_url(testCase), 'https://www.amazon.ca/dp/B08CGGRZ3M/')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Unit test output

```
$ python3 modules/Amazon/test_amazon_url_utils.py
....
----------------------------------------------------------------------
Ran 4 tests in 0.002s

OK
```

### Bot output

```
[✓] main.py Started
[!] Now logging to logfile.log, errors
[✓] Token Read: <REDACTED>
[✓] Discord.py Version: 1.5.1
[✓] Python Version: 3.7.3
[✓] Database Found
[!] LOADING MODULES:
   [✓] Bot_Management Loaded
   [✓] Amazon Loaded
[✓] Modules Loaded
[✓] Bot Ready! Logged in as Benchybot#1227
```

### Bot behavior

![image](https://user-images.githubusercontent.com/102862/100992734-63c89680-3509-11eb-8429-ecbe2842be7f.png)
